### PR TITLE
Make module context-aware

### DIFF
--- a/lib/lzo.cc
+++ b/lib/lzo.cc
@@ -28,7 +28,7 @@ lzo_uint decompress(const unsigned char *input, unsigned char *output, lzo_uint 
 }
 
 void js_compress(const v8::FunctionCallbackInfo<Value>& args) {
-    Isolate* isolate = Isolate::GetCurrent();
+    Isolate* isolate = args.GetIsolate();
     HandleScope scope(isolate);
 
     Handle<Object> inputBuffer = args[0]->ToObject();
@@ -54,7 +54,7 @@ void js_compress(const v8::FunctionCallbackInfo<Value>& args) {
 }
 
 void js_decompress(const v8::FunctionCallbackInfo<Value>& args) {
-    Isolate* isolate = Isolate::GetCurrent();
+    Isolate* isolate = args.GetIsolate();
     HandleScope scope(isolate);
 
     Handle<Object> inputBuffer = args[0]->ToObject();
@@ -81,8 +81,8 @@ void js_decompress(const v8::FunctionCallbackInfo<Value>& args) {
     args.GetReturnValue().Set(ret);
 }
 
-void Init(Handle<Object> exports) {
-    Isolate *isolate = Isolate::GetCurrent();
+void Init(Local<Object> exports, Local<Context> context) {
+    Isolate* isolate = context->GetIsolate();
 
     int init_result = lzo_init();
 
@@ -116,4 +116,7 @@ void Init(Handle<Object> exports) {
         String::NewFromUtf8(isolate, lzo_version_date()));
 }
 
-NODE_MODULE(node_lzo, Init);
+// Initialize this addon to be context-aware.
+NODE_MODULE_INIT(/* exports, module, context */) {
+    Init(exports, context);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -14,10 +14,10 @@ const randChar = () => String.fromCharCode(Math.random() * 1000);
 const toBuf = a => Buffer.from(a);
 
 describe('Compression/Decompression', () => {
-  it('lzo.compress should throw if nothing is passed', () => 
+  it('lzo.compress should throw if nothing is passed', () =>
     expect(() => lzo.decompress()).to.throw() );
 
-  it('lzo.decompress throw if nothing is passed', () => 
+  it('lzo.decompress throw if nothing is passed', () =>
     expect(() => lzo.decompress()).to.throw() );
 
   it('Decompressed date should be the same as the initial input', () => {
@@ -30,12 +30,21 @@ describe('Compression/Decompression', () => {
 });
 
 describe('Properties', () => {
-  it('Should have property \'version\'', () => 
+  it('Should have property \'version\'', () =>
     expect(lzo).to.have.ownProperty('version') );
 
-  it('Should have property \'versionDate\'', () => 
+  it('Should have property \'versionDate\'', () =>
     expect(lzo).to.have.ownProperty('versionDate') );
 
   it('Should have property \'errors\' (lzo error codes)', () =>
     expect(lzo).to.have.ownProperty('errors') );
+});
+
+describe('Module loaded in multiple contexts', () => {
+  it('Should not throw an error when module is loaded multiple times', () => {
+    delete require.cache[require.resolve('..')];
+    delete require.cache[require.resolve('../build/Release/node_lzo.node')];
+    const lzo2 = require('..');
+    expect(() => lzo2.compress(toBuf(arr(sampleSize)))).to.not.throw();
+  });
 });


### PR DESCRIPTION
In order to load the module in multiple contexts, such as in a parent thread and a worker thread, we need to be context-aware.

Fixes #10 

### References
* https://nodejs.org/api/addons.html#addons_context_aware_addons
* https://github.com/nodejs/node/issues/21783#issuecomment-429637117